### PR TITLE
ci: add banned import checker + branch protection

### DIFF
--- a/.github/workflows/check-submission.yml
+++ b/.github/workflows/check-submission.yml
@@ -1,0 +1,38 @@
+name: Check submission safety
+on:
+  pull_request:
+    paths: ['task4/**']
+  push:
+    paths: ['task4/**']
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for banned imports
+        run: |
+          BANNED="os|sys|subprocess|socket|ctypes|builtins|importlib|pickle|marshal|shelve|shutil|yaml|requests|urllib|http\.client|multiprocessing|threading|signal|gc\b|code\b|codeop|pty"
+          FAILED=0
+          for f in task4/*.py; do
+            [ -f "$f" ] || continue
+            echo "Checking $f..."
+            while IFS= read -r line; do
+              [[ "$line" =~ ^[[:space:]]*# ]] && continue
+              if echo "$line" | grep -qE "^(import|from) ($BANNED)"; then
+                echo "❌ BANNED in $f: $line"
+                FAILED=1
+              fi
+            done < "$f"
+            for func in "eval(" "exec(" "compile(" "__import__"; do
+              if grep -q "$func" "$f"; then
+                echo "❌ BANNED FUNCTION in $f: $func"
+                FAILED=1
+              fi
+            done
+          done
+          if [ $FAILED -eq 1 ]; then
+            echo "⛔ Submission contains banned imports — fix before submitting"
+            exit 1
+          fi
+          echo "✅ All Python files clean"

--- a/scripts/check-submission.sh
+++ b/scripts/check-submission.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Pre-submission security check — run before uploading any zip
+# Usage: ./scripts/check-submission.sh task4/run.py
+
+set -e
+
+FILE="${1:-task4/run.py}"
+
+if [ ! -f "$FILE" ]; then
+    echo "❌ File not found: $FILE"
+    exit 1
+fi
+
+echo "=== Checking $FILE for banned imports ==="
+
+BANNED="os|sys|subprocess|socket|ctypes|builtins|importlib|pickle|marshal|shelve|shutil|yaml|requests|urllib|http\.client|multiprocessing|threading|signal|gc\b|code\b|codeop|pty"
+
+FOUND=0
+while IFS= read -r line; do
+    # Skip comments
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    # Check imports
+    if echo "$line" | grep -qE "^(import|from) ($BANNED)"; then
+        echo "❌ BANNED: $line"
+        FOUND=1
+    fi
+done < "$FILE"
+
+# Check banned functions
+for func in "eval(" "exec(" "compile(" "__import__"; do
+    if grep -q "$func" "$FILE"; then
+        echo "❌ BANNED FUNCTION: $func"
+        FOUND=1
+    fi
+done
+
+if [ $FOUND -eq 0 ]; then
+    echo "✅ All clean — no banned imports or functions"
+else
+    echo ""
+    echo "⛔ DO NOT SUBMIT — fix banned imports first"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- GitHub Actions workflow checks task4/*.py for banned imports on every PR/push
- Local script: `scripts/check-submission.sh`
- Branch protection enabled: PRs required for main

## Banned imports detected
`os, sys, subprocess, socket, ctypes, builtins, importlib, pickle, marshal, shelve, shutil, yaml, requests, urllib, http.client, multiprocessing, threading, signal, gc, code, codeop, pty`

Prevents the auto-ban that hit us earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)