### PR TITLE
fix: SI POST currency/voucherDate + Nynorsk motteke

### DIFF
--- a/task2/solution.py
+++ b/task2/solution.py
@@ -243,7 +243,7 @@ def regex_parse(prompt):
         if re.search(r'kreditnota|credit\s*note|gutschrift|nota\s+de\s+crédito', pl):
             return {"task_type": "create_credit_note", "entities": {}}
         # Supplier invoice (incoming)
-        if re.search(r'leverandør|supplier|lieferant|fornecedor|fournisseur|proveedor', pl) and re.search(r'mottatt|received|erhalten|recibido|reçu|recebemos|registrer.*faktura|registre.*fatura', pl):
+        if re.search(r'leverandør|supplier|lieferant|fornecedor|fournisseur|proveedor', pl) and re.search(r'mottatt|motteke|received|erhalten|recibido|reçu|recebemos|registrer.*faktura|registre.*fatura', pl):
             supplier_name = find_name_after(p, 'leverandøren', 'Lieferanten', 'supplier', 'fournisseur', 'proveedor', 'fornecedor')
             org = find_org(p)
             inv_match = re.search(r'(INV[\w-]+)', p)
@@ -1477,6 +1477,8 @@ def handle_register_supplier_invoice(base_url, token, e):
         "invoiceNumber": e.get("invoiceNumber") or "",
         "amountCurrency": round(total_incl, 2),
         "supplier": {"id": supplier_id} if supplier_id else None,
+        "currency": {"code": "NOK"},
+        "voucherDate": inv_date,
     }
     if si_minimal.get("supplier") is None:
         si_minimal.pop("supplier", None)
@@ -3342,7 +3344,7 @@ async def _solve_inner(request: Request):
     return JSONResponse({"status": "completed"})
 
 
-BUILD_VERSION = "v20260321-2345"
+BUILD_VERSION = "v20260321-2355"
 
 @app.get("/health")
 def health():

--- a/task2/test_e2e_all.py
+++ b/task2/test_e2e_all.py
@@ -504,6 +504,17 @@ TESTS = [
         "checks": lambda p, m: True,
         "complex": True,  # PDF task — needs LLM
     },
+
+    # --- SUPPLIER INVOICE (Nynorsk) ---
+    {
+        "prompt": "Me har motteke faktura INV-2026-6998 frå leverandøren Sjøbris AS (org.nr 932482207) på 76850 kr inklusiv MVA. Beløpet gjeld kontortenester (konto 7140). Registrer leverandørfakturaen med korrekt inngåande MVA (25 %).",
+        "task_type": "register_supplier_invoice",
+        "checks": lambda p, m: (
+            p["entities"]["invoiceNumber"] == "INV-2026-6998"
+            and p["entities"]["totalAmountInclVat"] == 76850.0
+            and p["entities"]["accountNumber"] == 7140
+        ),
+    },
 ]
 
 

--- a/task2/test_regression.py
+++ b/task2/test_regression.py
@@ -1312,6 +1312,38 @@ def test_C23_payment_excludes_project_keywords():
             assert plan["task_type"] != "register_payment", f"'{prompt[:50]}' misclassified as register_payment"
 
 
+def test_C24_nynorsk_supplier_invoice():
+    """Competition: Nynorsk supplier invoice with 'motteke' (scored 0/8)."""
+    plan = regex_parse("Me har motteke faktura INV-2026-6998 frå leverandøren Sjøbris AS (org.nr 932482207) på 76850 kr inklusiv MVA. Beløpet gjeld kontortenester (konto 7140). Registrer leverandørfakturaen med korrekt inngåande MVA (25 %).")
+    assert plan is not None, "regex_parse should handle Nynorsk supplier invoice"
+    assert plan["task_type"] == "register_supplier_invoice", f"Got {plan['task_type']}"
+    e = plan["entities"]
+    assert e["supplierName"] == "Sjøbris AS"
+    assert e["invoiceNumber"] == "INV-2026-6998"
+    assert e["totalAmountInclVat"] == 76850.0
+    assert e["accountNumber"] == 7140
+
+
+def test_C25_supplier_invoice_has_currency():
+    """Supplier invoice POST body should include currency field."""
+    from task2.solution import handle_register_supplier_invoice, normalize_entities
+    mock = APIMock()
+    entities = normalize_entities({
+        "supplierName": "Test AS", "organizationNumber": "123456789",
+        "invoiceNumber": "INV-001", "totalAmountInclVat": 12500,
+        "netAmount": 10000, "vatAmount": 2500, "vatRate": 25, "accountNumber": 6540,
+    })
+    with patch('task2.solution.tx_get', mock.get), \
+         patch('task2.solution.tx_post', mock.post), \
+         patch('task2.solution.tx_put', mock.put):
+        handle_register_supplier_invoice("https://mock/v2", "tok", entities)
+    si = posts(mock, "/supplierInvoice")
+    assert len(si) >= 1, "Should attempt SI POST"
+    body = si[0][2]
+    assert body.get("currency") == {"code": "NOK"}, f"Missing currency: {body.get('currency')}"
+    assert body.get("voucherDate") is not None, "Missing voucherDate"
+
+
 # ============================================================
 # Run
 # ============================================================


### PR DESCRIPTION
## Summary
- Add `currency: {code: "NOK"}` and `voucherDate` to supplierInvoice POST body (proxy returns 500 without these — scored 0/8)
- Add Nynorsk `motteke` to received detection regex
- 2 new regression tests (C24-C25), 1 new E2E test

## Test plan
- [x] 62/62 regression, 49/49 E2E, 7/7 smoke — all pass