### PR TITLE
fix: PT order→invoice→payment misclassified as register_payment

### DIFF
--- a/task2/solution.py
+++ b/task2/solution.py
@@ -226,7 +226,7 @@ def regex_parse(prompt):
 
     # === PAYMENT (check before invoice — payment prompts also mention "invoice"/"faktura") ===
     if re.search(r'betaling|payment|zahlung|pago|paiement|pagamento', pl):
-        if not re.search(r'opprett|create|erstell|crea|créez|fastpris|fixed\s*price|precio\s+fijo|prix\s+fixe|preço\s+fixo|delbetaling|milestone', pl):  # Not project invoice or create
+        if not re.search(r'opprett|create|erstell|crea|crie|créez|fastpris|fixed\s*price|precio\s+fijo|prix\s+fixe|preço\s+fixo|delbetaling|milestone|pedido|ordre|order.*invoice|konverter|converta|convert', pl):  # Not project invoice, order→invoice, or create
             cust_name = find_name_after(p, 'kunden', 'customer', 'kunde', 'client', 'cliente')
             cust_org = find_org(p)
             amt = find_amount(p)
@@ -3346,7 +3346,7 @@ async def _solve_inner(request: Request):
             import re as _re
             prompt_no_email = _re.sub(r'[\w.+-]+@[\w.-]+', '', prompt.lower())
             # Count distinct action VERBS only (not nouns like faktura/invoice)
-            action_verbs = set(_re.findall(r'\b(?:opprett|create|registrer|registe|slett|delete|send|generer|generate|gere|oppdater|update|reverser|reverse|kjør|run|konverter|convert|créez|erstellen|envoyez|senden|fakturer|sett\s+fastpris|set\s+fixed|completa|configura)\b', prompt_no_email))
+            action_verbs = set(_re.findall(r'\b(?:opprett|create|crie|registrer|registe|slett|delete|send|generer|generate|gere|oppdater|update|reverser|reverse|kjør|run|konverter|converta|convert|créez|erstellen|envoyez|senden|fakturer|sett\s+fastpris|set\s+fixed|completa|configura)\b', prompt_no_email))
             if len(action_verbs) >= 2:
                 print(f"COMPLEX prompt ({len(prompt)} chars, {len(action_verbs)} actions) — forcing LLM")
                 plan = None
@@ -3372,7 +3372,7 @@ async def _solve_inner(request: Request):
     return JSONResponse({"status": "completed"})
 
 
-BUILD_VERSION = "v20260322-0025"
+BUILD_VERSION = "v20260322-0030"
 
 @app.get("/health")
 def health():

--- a/task2/test_e2e_all.py
+++ b/task2/test_e2e_all.py
@@ -90,7 +90,7 @@ def run_prompt(prompt):
     # Complexity guard: long prompts with 3+ actions → force LLM
     if plan and len(prompt) > 200:
         prompt_no_email = _re.sub(r'[\w.+-]+@[\w.-]+', '', prompt.lower())
-        action_verbs = set(_re.findall(r'\b(?:opprett|create|registrer|registe|slett|delete|send|generer|generate|gere|oppdater|update|reverser|reverse|kjør|run|konverter|convert|créez|erstellen|envoyez|senden|fakturer|sett\s+fastpris|set\s+fixed|completa|configura)\b', prompt_no_email))
+        action_verbs = set(_re.findall(r'\b(?:opprett|create|crie|registrer|registe|slett|delete|send|generer|generate|gere|oppdater|update|reverser|reverse|kjør|run|konverter|converta|convert|créez|erstellen|envoyez|senden|fakturer|sett\s+fastpris|set\s+fixed|completa|configura)\b', prompt_no_email))
         if len(action_verbs) >= 2:
             plan = None
     if not plan:
@@ -514,6 +514,14 @@ TESTS = [
             and p["entities"]["totalAmountInclVat"] == 76850.0
             and p["entities"]["accountNumber"] == 7140
         ),
+    },
+
+    # --- ORDER→INVOICE→PAYMENT (must NOT be register_payment) ---
+    {
+        "prompt": "Crie um pedido para o cliente Cascata Lda (org. nº 927161524) com os produtos Consultoria de dados (8400) a 5700 NOK e Design web (2535) a 3850 NOK. Converta o pedido em fatura e registe o pagamento total.",
+        "task_type": "invoice_with_payment",
+        "checks": lambda p, m: True,
+        "complex": True,
     },
 ]
 

--- a/task2/test_regression.py
+++ b/task2/test_regression.py
@@ -1409,6 +1409,15 @@ def test_C28_complexity_guard_no_crash():
     # The key assertion is: no crash
 
 
+def test_C29_order_invoice_payment_not_register_payment():
+    """Competition: Portuguese order→invoice→payment must NOT be register_payment (scored 0/8)."""
+    plan = regex_parse('Crie um pedido para o cliente Cascata Lda (org. nº 927161524) com os produtos Consultoria de dados (8400) a 5700 NOK e Design web (2535) a 3850 NOK. Converta o pedido em fatura e registe o pagamento total.')
+    # Should NOT be register_payment — pedido/crie/converta should exclude
+    if plan:
+        assert plan["task_type"] != "register_payment", f"Misclassified as register_payment! Got: {plan['task_type']}"
+    # The key assertion is: no crash
+
+
 # ============================================================
 # Run
 # ============================================================


### PR DESCRIPTION
## Summary
- Add crie/pedido/converta/convert to payment exclusion regex
- Add crie/converta to complexity guard action verbs
- Portuguese "Crie um pedido...Converta...registe o pagamento" was 0/8
- Test C29 + E2E for PT order→invoice→payment

## Test plan
- [x] 66/66 regression, 50/50 E2E, 7/7 smoke — all pass