### PR TITLE
fix: safe int conversion for LLM account values

### DIFF
--- a/task2/solution.py
+++ b/task2/solution.py
@@ -1423,7 +1423,10 @@ def handle_register_supplier_invoice(base_url, token, e):
     vat_amount = float(e.get("vatAmount") or (total_incl - net_amount))
 
     # Find the expense account (from prompt, default 6540)
-    acct_number = int(e.get("accountNumber") or e.get("account") or 6540)
+    try:
+        acct_number = int(e.get("accountNumber") or e.get("account") or 6540)
+    except (ValueError, TypeError):
+        acct_number = 6540
     expense_acct_id = find_account_id(base_url, token, acct_number)
     if not expense_acct_id:
         expense_acct_id = find_account_id(base_url, token, 6540)
@@ -2398,7 +2401,10 @@ def handle_create_accounting_dimension(base_url, token, e):
 
     # Step 3: Post voucher linked to a dimension value (if requested)
     voucher_data = e.get("voucher", {})
-    acct_number = int(e.get("accountNumber") or voucher_data.get("accountNumber") or voucher_data.get("account") or e.get("account") or 0)
+    try:
+        acct_number = int(e.get("accountNumber") or voucher_data.get("accountNumber") or voucher_data.get("account") or e.get("account") or 0)
+    except (ValueError, TypeError):
+        acct_number = 0
     amount = float(e.get("amount") or voucher_data.get("amount") or 0)
     linked_value = e.get("linkedDimensionValue") or voucher_data.get("linkedDimensionValue") or voucher_data.get("dimensionValue")
 
@@ -2697,9 +2703,12 @@ def handle_year_end_closing(base_url, token, e):
                 years = int(asset.get("depreciationYears") or 1)
                 annual = cost / years
                 dep_amount = round(annual / 12, 2) if is_monthly else round(annual, 2)
-            exp_num = int(asset.get("expenseAccount") or 6010)
-            acc_num = int(asset.get("accumulatedDepreciationAccount") or 1209)
-            asset_acct_num = int(asset.get("assetAccount") or 0)
+            def _safe_int(v, default):
+                try: return int(v)
+                except (ValueError, TypeError): return default
+            exp_num = _safe_int(asset.get("expenseAccount"), 6010)
+            acc_num = _safe_int(asset.get("accumulatedDepreciationAccount"), 1209)
+            asset_acct_num = _safe_int(asset.get("assetAccount"), 0)
             expense_acct = find_account_id(base_url, token, exp_num)
             # Try specified account first, then create it if not found
             accum_acct = find_account_id(base_url, token, acc_num)
@@ -3438,7 +3447,7 @@ async def _solve_inner(request: Request):
     return JSONResponse({"status": "completed"})
 
 
-BUILD_VERSION = "v20260322-0215"
+BUILD_VERSION = "v20260322-0800"
 
 @app.get("/health")
 def health():

--- a/task2/test_regression.py
+++ b/task2/test_regression.py
@@ -1514,6 +1514,36 @@ def test_M08_german_festpreis_not_payment():
     assert plan is None, f"German Festpreis should go to LLM, got {plan['task_type'] if plan else None}"
 
 
+def test_M09_unknown_account_values_no_crash():
+    """Year-end/month-end: LLM returns 'unknown' for account numbers — must not crash."""
+    from task2.solution import handle_year_end_closing, normalize_entities
+    mock = APIMock()
+    entities = normalize_entities({
+        "closingYear": 2026, "closingMonth": 3,
+        "depreciationAssets": [{
+            "assetName": "Fixed asset", "originalCost": 292100,
+            "assetAccount": "unknown", "depreciationYears": 6,
+            "expenseAccount": "6030", "accumulatedDepreciationAccount": "unknown",
+        }],
+        "prepaidAmount": 14600, "prepaidAccount": "1720",
+    })
+    with patch('task2.solution.tx_get', mock.get), \
+         patch('task2.solution.tx_post', mock.post), \
+         patch('task2.solution.tx_put', mock.put):
+        # Should NOT crash with ValueError
+        handle_year_end_closing("https://mock/v2", "tok", entities)
+    # Verify voucher was still created
+    vouchers = posts(mock, "/ledger/voucher")
+    assert len(vouchers) >= 1, "Should still create depreciation voucher with default accounts"
+
+
+def test_M10_spanish_hito_not_payment():
+    """Spanish 'hito' (milestone) must NOT be register_payment."""
+    plan = regex_parse('Establezca un precio fijo de 300000 NOK. Facture al cliente 50% como pago por hito.')
+    if plan:
+        assert plan["task_type"] != "register_payment", f"hito misclass as {plan['task_type']}"
+
+
 # ============================================================
 # Run
 # ============================================================


### PR DESCRIPTION
## Summary
- Safe int conversion for all entity account numbers (LLM returns "unknown" → crash)
- Currency payment paidAmountCurrency + reverse voucher bank filter
- Spanish hito/French jalon milestone exclusion
- Tests M09-M10

## Test plan
- [x] 76/76 regression, 66/66 E2E, 7/7 smoke — all pass