### PR TITLE
fix: Nynorsk month-end misclassified as payroll

### DIFF
--- a/task2/solution.py
+++ b/task2/solution.py
@@ -225,7 +225,7 @@ def regex_parse(prompt):
         r'avstem|reconcil|abstimm|concili|rapprocher|bankutskrift|bank\s*statement|extrato\s*banc',  # bank reconciliation
         r'reverser|reverse|stornieren|annuler|anular|reverter|devolvido|retourné|returned.*bank',  # reverse voucher
         r'feil i hovedbok|errors? in.*ledger|fehler.*hauptbuch|errores.*libro.*mayor|erreurs.*grand.*livre|erros.*livro',  # ledger correction
-        r'årsoppgjør|year.end.*closing|jahresabschluss|monatsabschluss|cierre.*anual|clôture.*annuel|encerramento.*anual|månedsslutt|month.end.*closing|clôture.*mensuel|cierre.*mensual|encerramento.*mensal|rechnungsabgr',  # year-end/month-end
+        r'årsoppgjør|year.end.*closing|jahresabschluss|monatsabschluss|cierre.*anual|clôture.*annuel|encerramento.*anual|månedsslutt|månavslutn|month.end.*closing|clôture.*mensuel|cierre.*mensual|encerramento.*mensal|rechnungsabgr',  # year-end/month-end
         r'analysier|analyse.*hauptbuch|analyze.*ledger|analise.*livro|trois.*comptes|three.*accounts|drei.*konten',  # ledger analysis
         r'livssyklus|lifecycle|lebenszyklus|ciclo.*vida|cycle.*vie',  # project lifecycle
         r'valutadifferanse|exchange.*rate.*differ|wechselkurs|tipo.*cambio|taux.*change|taxa.*câmbio|agio|disagio',  # currency payment
@@ -3557,7 +3557,7 @@ async def _solve_inner(request: Request):
     return JSONResponse({"status": "completed"})
 
 
-BUILD_VERSION = "v20260322-0840"
+BUILD_VERSION = "v20260322-0845"
 
 @app.get("/health")
 def health():

--- a/task2/test_regression.py
+++ b/task2/test_regression.py
@@ -1544,6 +1544,12 @@ def test_M10_spanish_hito_not_payment():
         assert plan["task_type"] != "register_payment", f"hito misclass as {plan['task_type']}"
 
 
+def test_M11_nynorsk_month_end_not_payroll():
+    """Nynorsk månavslutninga must NOT be run_payroll (scored 2/10)."""
+    plan = regex_parse('Gjer månavslutninga for mars 2026. Periodiser forskotsbetalt kostnad (11700 kr per månad frå konto 1720 til kostnadskonto). Bokfør månadleg avskriving for eit driftsmiddel med innkjøpskost 191700 kr og levetid 7 år (lineær avskriving til konto 6030). Kontroller at saldobalansen går i null. Bokfør også ei lønnsavsetjing (debet lønnskostnad konto 5000, kredit påløpt lønn konto 2900).')
+    assert plan is None, f"Nynorsk month-end should go to LLM, got {plan['task_type'] if isinstance(plan, dict) else plan}"
+
+
 # ============================================================
 # Run
 # ============================================================


### PR DESCRIPTION
Added månavslutn to complex patterns. Test M11. 77/77 + 66/66 pass.